### PR TITLE
fix(mcp): use dnx for roslyn and nuget (closes #24)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,8 +4,8 @@
       "url": "http://127.0.0.1:3000/mcp"
     },
     "roslyn": {
-      "command": "/Users/matt/.dotnet/tools/roslyn-mcp",
-      "args": [],
+      "command": "dnx",
+      "args": ["RoslynMcp.Server", "-y", "--allow-roll-forward"],
       "env": {}
     },
     "blender": {
@@ -24,8 +24,8 @@
       "env": {}
     },
     "nuget": {
-      "command": "dotnet",
-      "args": ["tool", "run", "nuget.mcp.server"],
+      "command": "dnx",
+      "args": ["NuGet.Mcp.Server", "-y"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary

- Replace hardcoded personal path + broken `dotnet tool run` invocations with canonical `dnx` launches for both `roslyn` and `nuget` MCP servers
- Add `--allow-roll-forward` to roslyn so the net9-targeted `RoslynMcp.Server` runs cleanly on a .NET 10-only machine
- Fix `nuget` package ID to the canonical [`NuGet.Mcp.Server`](https://www.nuget.org/packages/NuGet.Mcp.Server) (official Microsoft)

Closes #24.

## The three bugs (all in `.mcp.json`)

| Bug | Before | After |
|---|---|---|
| Personal path | `/Users/matt/.dotnet/tools/roslyn-mcp` | `dnx RoslynMcp.Server` |
| net9 runtime required | no roll-forward | `--allow-roll-forward` |
| Tool manifest resolution | `dotnet tool run nuget.mcp.server` | `dnx NuGet.Mcp.Server` |

## Why `dnx`?

`dnx` ships with the .NET 10 SDK and is documented by Microsoft as the canonical way to launch .NET-based MCP servers ([NuGet MCP Server docs](https://learn.microsoft.com/en-us/nuget/concepts/nuget-mcp-server)). It resolves packages straight from nuget.org on demand — no global install, no tool manifest, no personal paths. `--allow-roll-forward` is a built-in flag that tells the .NET host to forward to a newer runtime major version if the target framework isn't installed, which is exactly what we need for RoslynMcp.Server v0.4.0 (which targets net9.0 and has no net10 build yet).

## Test plan

- [x] Patch `.mcp.json` in plugin cache locally, run `/reload-plugins`
- [x] `claude mcp list` reports both servers `✓ Connected`:
  ```
  plugin:dt-brigid:roslyn: dnx RoslynMcp.Server -y --allow-roll-forward - ✓ Connected
  plugin:dt-brigid:nuget:  dnx NuGet.Mcp.Server -y                      - ✓ Connected
  ```
- [x] 41 roslyn tools surface in the session (`mcp__plugin_dt-brigid_roslyn__*`)
- [x] 5 nuget tools surface in the session (`mcp__plugin_dt-brigid_nuget__*`)
- [x] Roll-forward verified: RoslynMcp.Server v0.4.0 (net9.0) runs without crash on a machine with only .NET 10.0.5 installed
- [ ] **Reviewer action:** merge, bump plugin version, rebuild marketplace

## Prerequisite for users

.NET 10 SDK is required for the `dnx` command. Worth adding to the plugin README's install section in a follow-up.